### PR TITLE
Add support for mdns http and ssh services

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <queries>
         <intent>


### PR DESCRIPTION
With this change two mdns services are started (ssh and http). Unfortunately its not easy to change the default hostname, so for now one has to use the `android.local` address.